### PR TITLE
Add support for PHP 8.x

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,6 +19,10 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+    - name: Install MongoDB
+      uses: supercharge/mongodb-github-action@1.8.0
+      with:
+        mongodb-version: '4.2'
     - name: Validate composer.json and composer.lock
       run: composer validate
     - name: Install dependencies

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,9 +1,11 @@
 filter:
     excluded_paths:
         - 'vendor/*'
-before_commands:
-    - 'composer install --prefer-source'
 build:
+    environment:
+        php:
+            pecl_extensions:
+                - mongodb
     nodes:
         analysis:
             tests:

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.0",
+        "php": "^7.3 || ^8.0",
         "mongodb/mongodb": "^1.1",
         "psr/simple-cache": "^1.0",
-        "subjective-php/psr-cache-helper": "^1.1.1"
+        "subjective-php/psr-cache-helper": "^2.1"
     },
     "license": "MIT",
     "require-dev": {
-        "phpunit/phpunit": "^6.1",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {

--- a/tests/MongoCacheTest.php
+++ b/tests/MongoCacheTest.php
@@ -39,7 +39,7 @@ final class MongoCacheTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->collection = (new Client())->selectDatabase('testing')->selectCollection('cache');
         $this->collection->drop();
@@ -119,13 +119,13 @@ final class MongoCacheTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @covers ::set
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage $ttl must be null, an integer or \DateInterval instance
      *
      * @return void
      */
     public function setInvalidTTL()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$ttl must be null, an integer or \DateInterval instance');
         $this->cache->set('key', new DateTime(), new DateTime());
     }
 
@@ -134,13 +134,13 @@ final class MongoCacheTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @covers ::set
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage $key must be a valid non empty string
      *
      * @return void
      */
     public function setEmptyKey()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key must be a valid non empty string');
         $this->cache->set('', new DateTime());
     }
 
@@ -149,13 +149,13 @@ final class MongoCacheTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @covers ::set
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage $key must be a valid non empty string
      *
      * @return void
      */
     public function setNonStringKey()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key must be a valid non empty string');
         $this->cache->set(new \StdClass(), new DateTime());
     }
 
@@ -164,13 +164,13 @@ final class MongoCacheTest extends \PHPUnit\Framework\TestCase
      *
      * @test
      * @covers ::set
-     * @expectedException \Psr\SimpleCache\InvalidArgumentException
-     * @expectedExceptionMessage Key 'key with {, ) & @' contains unsupported characters
      *
      * @return void
      */
     public function setKeyContainsReservedCharacters()
     {
+        $this->expectException(\Psr\SimpleCache\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Key \'key with {, ) & @\' contains unsupported characters');
         $this->cache->set('key with {, ) & @', new DateTime());
     }
 
@@ -405,11 +405,11 @@ final class MongoCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(
             [
                 '_id' => $key,
-                'expires' => $actual['expires'],
                 'data' => [
                     'timestamp' => $expected->getTimestamp(),
                     'timezone' => $expected->getTimeZone()->getName(),
                 ],
+                'expires' => $actual['expires'],
             ],
             $actual
         );


### PR DESCRIPTION
#### What does this PR do?
Add support for PHP 8.x
Backwards breaking; removes support for PHP 7.2 and older.

#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
